### PR TITLE
switching to pytorch docker container base

### DIFF
--- a/directai_fastapi/Dockerfile
+++ b/directai_fastapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn:python3.10-slim-2023-04-03
+FROM pytorch/pytorch:2.3.1-cuda12.1-cudnn8-runtime
 WORKDIR /directai_fastapi
 
 COPY requirements.txt .

--- a/directai_fastapi/requirements.txt
+++ b/directai_fastapi/requirements.txt
@@ -1,1 +1,3 @@
-fastapi==0.87.0
+uvicorn[standard]==0.20.0
+gunicorn==22.0.0
+fastapi[all]==0.88.0


### PR DESCRIPTION
All the FastAPI docker container base does is install FastAPI and its dependencies via pip into the Python 3.10 container. In order to use it, we have to install all the pytorch dependencies within that, which is very slow. Instead, we can use PyTorch's optimized Nvidia base package for python 3.10 and do the same pip install that FastAPI's container does. This significantly speeds up our build process, especially when we change requirements.txt, and also may give us a performance boost.